### PR TITLE
Enabling metrics collection in aws.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,18 @@
             <scope>runtime</scope>
         </dependency>
         
+        
+        
+       <!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk-cloudwatch -->
+		<dependency>
+		    <groupId>com.amazonaws</groupId>
+		    <artifactId>aws-java-sdk-cloudwatch</artifactId>
+		    <version>1.11.204</version>
+		</dependency>
+        
+        
+        
+        
         <!--easypost shipping-->
         <!-- https://mvnrepository.com/artifact/com.easypost/easypost-api-client -->
         <dependency>

--- a/src/main/java/com/weavers/duqhan/controller/HomeController.java
+++ b/src/main/java/com/weavers/duqhan/controller/HomeController.java
@@ -5,12 +5,15 @@
  */
 package com.weavers.duqhan.controller;
 
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
 import com.weavers.duqhan.business.ProductService;
 import com.weavers.duqhan.business.UsersService;
 import com.weavers.duqhan.dto.CategorysBean;
 import com.weavers.duqhan.dto.LoginBean;
 import com.weavers.duqhan.dto.ProductRequistBean;
 import com.weavers.duqhan.dto.UserBean;
+import com.weavers.duqhan.util.AwsCloudWatchHelper;
+
 import java.io.IOException;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.log4j.Logger;
@@ -29,12 +32,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class HomeController {
 
+	private AwsCloudWatchHelper awsCloudWatchHelper = new AwsCloudWatchHelper();
+	
     @Autowired
     UsersService usersService;
     @Autowired
     ProductService productService;
 
     private final Logger logger = Logger.getLogger(HomeController.class);
+    
+    //use this dimension name and value for all API error logging to AWS.
+    private final String errorDimensionName = "Api error";
+    private final String errordDimensionValue = "Api error value";
 
     @RequestMapping(value = "/", method = RequestMethod.GET)
     public void home(HttpServletResponse response) throws IOException {
@@ -51,15 +60,45 @@ public class HomeController {
 
     @RequestMapping(value = "/fb-login", method = RequestMethod.POST)   // login by FaceBook old user as well as new user. Auth-Token generate.
     public UserBean fbLogin(HttpServletResponse response, @RequestBody LoginBean loginBean) {
-        UserBean userBean = usersService.fbUserLogin(loginBean);
-        response.setStatus(Integer.valueOf(userBean.getStatusCode()));
+    	UserBean userBean = null;
+    	try {
+	    	userBean = usersService.fbUserLogin(loginBean);
+	        response.setStatus(Integer.valueOf(userBean.getStatusCode()));
+    	}catch (Exception e) {
+    		logger.error(e);
+    		int logErrorCount = awsCloudWatchHelper.logCount(errorDimensionName, errordDimensionValue, "Number of errors noticed", StandardUnit.Count, 1.0, "DUQHAN SITE/TRAFFIC");
+    		logger.info("Response code for AWS error log count: " + logErrorCount);
+    	}
         return userBean;
     }
 
     @RequestMapping(value = "/login", method = RequestMethod.POST)  // Log in by email only register user. Auth-Token generate.
     public UserBean login(HttpServletResponse response, @RequestBody LoginBean loginBean) {
-        UserBean userBean = usersService.userLogin(loginBean);
-        response.setStatus(Integer.valueOf(userBean.getStatusCode()));
+
+    	long loginStartTime = System.currentTimeMillis();
+        UserBean userBean = null;
+        
+    	try {
+    		userBean = usersService.userLogin(loginBean);
+	        response.setStatus(Integer.valueOf(userBean.getStatusCode()));
+	        
+	        long loginEndTime = System.currentTimeMillis();
+	        double timeTakenToLogin = (loginEndTime - loginStartTime)/1000.0;
+	        
+	        int logCountResponseCode = awsCloudWatchHelper.logCount("Login dimension", "Login dimension value", 
+	    			"Number of users using login(Duplicate users too)", StandardUnit.Count, 1.0, "DUQHAN SITE/TRAFFIC");
+	        logger.info("Response code for AWS log count: " + logCountResponseCode);
+	        
+	        int logTimeResponseCode = awsCloudWatchHelper.logTimeSecounds("Login start time",
+	        		"Login start value", "Time taken for the user login", StandardUnit.Seconds,
+	        		(loginEndTime - loginStartTime)/1000.0, "DUQHAN SITE/TRAFFIC");
+	        logger.info("Time taken to login: " + timeTakenToLogin + " Response code from AWS for logging time:" +logTimeResponseCode);
+    	} catch (Exception e) {
+    		logger.error(e);
+    		int logErrorCount = awsCloudWatchHelper.logCount(errorDimensionName, errordDimensionValue, "Number of errors noticed", StandardUnit.Count, 1.0, "DUQHAN SITE/TRAFFIC");
+    		logger.info("Response code for AWS error log count: " + logErrorCount);
+    	}
+        
         return userBean;
     }
 

--- a/src/main/java/com/weavers/duqhan/util/AwsCloudWatchHelper.java
+++ b/src/main/java/com/weavers/duqhan/util/AwsCloudWatchHelper.java
@@ -1,0 +1,99 @@
+package com.weavers.duqhan.util;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatch;
+import com.amazonaws.services.cloudwatch.AmazonCloudWatchClientBuilder;
+import com.amazonaws.services.cloudwatch.model.Dimension;
+import com.amazonaws.services.cloudwatch.model.MetricDatum;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataRequest;
+import com.amazonaws.services.cloudwatch.model.PutMetricDataResult;
+import com.amazonaws.services.cloudwatch.model.StandardUnit;
+
+/**
+ * A helper class to log various metrics to AWS.
+ * @author mamidilaxman
+ *
+ */
+public class AwsCloudWatchHelper {
+
+	private static final String awsAccessKey = "AKIAI7PN2XJSGU66DUNA";
+	private static final String awsSecretKey = "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";
+	private static AWSCredentialsProvider awsCredentialProvider;
+	private static final String awsRegion = "us-east-1";
+	private static AmazonCloudWatch cw;
+	
+	public AwsCloudWatchHelper() {
+		BasicAWSCredentials bawsCredentials =	new BasicAWSCredentials(awsAccessKey, awsSecretKey);
+		awsCredentialProvider = new AWSStaticCredentialsProvider(bawsCredentials);
+		cw = AmazonCloudWatchClientBuilder
+    			.standard()
+    			.withCredentials(awsCredentialProvider)
+    			.withRegion(awsRegion)
+    			.build();
+	}
+	
+	/**
+	 * This function helps to log a count value to AWS. It is typically an integer to count the number of events that you want to log.
+	 * @param dimensionName
+	 * @param dimensionValue
+	 * @param metricName
+	 * @param metricUnit
+	 * @param countValue
+	 * @param metricNameSpace
+	 * @return
+	 */
+	public int logCount(String dimensionName, String dimensionValue, String metricName, StandardUnit metricUnit, Double countValue,
+									String metricNameSpace) {
+		
+    	Dimension dimension = new Dimension()
+    							  .withName(dimensionName)
+    							  .withValue(dimensionValue);
+    	MetricDatum datum = new MetricDatum()
+    							  .withMetricName(metricName)
+    							  .withUnit(StandardUnit.Count)
+    							  .withValue(countValue)
+    							  .withDimensions(dimension);
+    	
+    	PutMetricDataRequest request = new PutMetricDataRequest()
+    						      			.withNamespace(metricNameSpace)
+    						      			.withMetricData(datum);
+    	PutMetricDataResult metricResponse = cw.putMetricData(request);
+    	return metricResponse.getSdkHttpMetadata().getHttpStatusCode();
+    	
+	}
+	
+	/**
+	 * This function helps to log a timestamp to AWS. It is typically a long value in seconds.
+	 * @param dimensionName
+	 * @param dimensionValue
+	 * @param metricName
+	 * @param metricUnit
+	 * @param timeToLog
+	 * @param metricNameSpace
+	 * @return
+	 */
+	public int logTimeSecounds(String dimensionName, String dimensionValue, String metricName, StandardUnit metricUnit, Double timeToLog,
+										String metricNameSpace) {
+	        
+	        Dimension timeDimension = new Dimension()
+	        									.withName(dimensionName)
+	        									.withValue(dimensionValue);
+	        MetricDatum timeDatum = new MetricDatum()
+	        						.withMetricName(metricName)
+	        						.withUnit(metricUnit)
+	        						.withValue(timeToLog)
+	        						.withDimensions(timeDimension);
+	        
+	        PutMetricDataRequest timeRequest = new PutMetricDataRequest()
+	      			.withNamespace(metricNameSpace)
+	      			.withMetricData(timeDatum);
+	        PutMetricDataResult loginMetricResponse = cw.putMetricData(timeRequest);
+	        return loginMetricResponse.getSdkHttpMetadata().getHttpStatusCode();
+		
+	}
+	
+	
+	
+}


### PR DESCRIPTION
This code helps to log metrics to AWS. I have created for login rest api and facebook login, please go ahead and create the same metrics for other apis also. 

At the bare minimum log metrics for exceptions in all apis.

Here is the cloudwatch dashboard:
https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#dashboards:name=Duqhan_CloudWatch


This is time taken for the login api dashboard:

https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2:graph=~(view~'timeSeries~stacked~false~metrics~(~(~'DUQHAN*20SITE*2fTRAFFIC~'Time*20taken*20for*20the*20user*20login~'Login*20start*20time~'Login*20start*20value))~region~'us-east-1~start~'-PT12H~end~'P0D)

This is number of times login api is called:

https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#metricsV2:graph=~(view~'timeSeries~stacked~false~region~'us-east-1~metrics~(~(~'DUQHAN*20SITE*2fTRAFFIC~'Number*20of*20users*20using*20login*28Duplicate*20users*20too*29~'Login*20dimension~'Login*20dimension*20value))~start~'-PT12H~end~'P0D)